### PR TITLE
fix: use native fetch for Google engine

### DIFF
--- a/src/core/engines/GoogleEngine.ts
+++ b/src/core/engines/GoogleEngine.ts
@@ -22,10 +22,14 @@ export class GoogleEngine implements Engine {
       generationConfig: { responseModalities: ['IMAGE'] }
     };
 
+    // Prefer the environment's built-in fetch if it exists; cross-fetch's polyfill
+    // can conflict with runtimes that already supply a fetch implementation, which
+    // manifested as network errors when calling the Google API.
+    const f: any = (globalThis as any).fetch || fetch;
     const controller = new AbortController();
     const to = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
-      const res = await (fetch as any)(this.endpoint(), {
+      const res = await f(this.endpoint(), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -1,10 +1,22 @@
 import { NanoBananaEngine } from '../src/core/engines/NanoBananaEngine';
 import { FluxEngine } from '../src/core/engines/FluxEngine';
+import { GoogleEngine } from '../src/core/engines/GoogleEngine';
 // Node polyfills for test
 // @ts-ignore
 global.atob = (b64)=> Buffer.from(b64, 'base64').toString('binary');
 // @ts-ignore
-global.fetch = (url, opts)=> Promise.resolve({ ok: true, status: 200, json: async () => ({ image: Buffer.from('PNGDATA').toString('base64') }) });
+global.fetch = (url, opts)=> Promise.resolve({
+  ok: true,
+  status: 200,
+  json: async () => {
+    const base64 = Buffer.from('PNGDATA').toString('base64');
+    return {
+      image: base64,
+      candidates: [{ content: { parts: [{ inline_data: { data: base64 } }] } }],
+      images: [{ image: { bytesBase64Encoded: base64 } }]
+    };
+  }
+});
 
 test('nanobanana engine returns bytes', async () => {
   const eng = new NanoBananaEngine('https://api.example.com', 'KEY');
@@ -15,5 +27,11 @@ test('nanobanana engine returns bytes', async () => {
 test('flux engine returns bytes', async () => {
   const eng = new FluxEngine('https://api.example.com', 'KEY');
   const res = await eng.generate({engine:'flux', prompt:'hello', negative:'', seed:null, strength:0.7, refWeight:0, refImage:null, region:null});
+  expect(res.image.byteLength).toBeGreaterThan(0);
+});
+
+test('google engine returns bytes', async () => {
+  const eng = new GoogleEngine('KEY');
+  const res = await eng.generate({engine:'google', prompt:'hello', negative:'', seed:null, strength:0.7, refWeight:0, refImage:null, region:null});
   expect(res.image.byteLength).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- avoid network failures in GoogleEngine by preferring global fetch
- expand engine tests with GoogleEngine
- document rationale for preferring native fetch over polyfill

## Testing
- `npm test` *(fails: coverage threshold not met)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7400b4fe8832da970d7b310230c61